### PR TITLE
Add real-time packet capture mode

### DIFF
--- a/agents/live_capture.py
+++ b/agents/live_capture.py
@@ -1,0 +1,223 @@
+"""
+Live Capture Agent — Real-time packet sniffing with scapy.
+
+Captures network packets from a specified interface, converts them
+to the same PacketRecord/ConnectionFlow format as PcapParser, and
+optionally saves the capture to a PCAP file for later analysis.
+
+Requires elevated privileges (root/admin) for raw socket access.
+"""
+
+import os
+import time
+from collections import defaultdict
+from datetime import datetime, timezone
+from threading import Event
+
+from scapy.all import DNS, ICMP, IP, TCP, UDP, sniff, wrpcap
+
+from models.network import ConnectionFlow, PacketRecord, ParseResult
+
+FLAG_MAP = {"S": "SYN", "A": "ACK", "R": "RST", "F": "FIN", "P": "PSH", "U": "URG"}
+
+
+class LiveCaptureAgent:
+    """
+    Captures live network traffic and produces a ParseResult
+    compatible with the existing analysis pipeline.
+
+    Usage:
+        agent = LiveCaptureAgent()
+        result = agent.capture(interface="en0", duration=30, max_packets=1000)
+    """
+
+    def __init__(self):
+        self._records: list[PacketRecord] = []
+        self._raw_packets: list = []
+        self._stop_event = Event()
+
+    def capture(
+        self,
+        interface: str | None = None,
+        duration: int = 30,
+        max_packets: int = 10000,
+        bpf_filter: str = "",
+        save_path: str | None = None,
+    ) -> ParseResult:
+        """
+        Capture live packets from a network interface.
+
+        Args:
+            interface:   Network interface (e.g., "en0", "eth0"). None for default.
+            duration:    Capture duration in seconds (max 300).
+            max_packets: Maximum packets to capture (max 100000).
+            bpf_filter:  BPF filter string (e.g., "tcp port 80").
+            save_path:   If set, save captured packets to this PCAP file.
+
+        Returns:
+            ParseResult with captured packets and flows.
+
+        Raises:
+            PermissionError: If not running with sufficient privileges.
+            ValueError: If no packets were captured.
+        """
+        duration = min(max(1, duration), 300)
+        max_packets = min(max(1, max_packets), 100000)
+
+        self._records = []
+        self._raw_packets = []
+        self._stop_event.clear()
+
+        sniff_kwargs = {
+            "prn": self._process_packet,
+            "store": True,
+            "timeout": duration,
+            "count": max_packets,
+        }
+
+        if interface:
+            sniff_kwargs["iface"] = interface
+        if bpf_filter:
+            sniff_kwargs["filter"] = bpf_filter
+
+        try:
+            captured = sniff(**sniff_kwargs)
+        except PermissionError:
+            raise PermissionError(
+                "Packet capture requires elevated privileges. "
+                "Run with sudo or as administrator."
+            )
+
+        self._raw_packets = list(captured)
+
+        if save_path and self._raw_packets:
+            os.makedirs(os.path.dirname(save_path) or ".", exist_ok=True)
+            wrpcap(save_path, self._raw_packets)
+
+        if not self._records:
+            raise ValueError(
+                "No IP packets captured. Check the interface name and filters."
+            )
+
+        flows = self._build_flows()
+        protocol_dist = self._count_protocols()
+
+        unique_src = {r.src_ip for r in self._records}
+        unique_dst = {r.dst_ip for r in self._records}
+        time_range = (
+            f"{self._records[0].timestamp} – {self._records[-1].timestamp}"
+            if self._records else ""
+        )
+
+        source_label = f"live:{interface or 'default'}"
+
+        return ParseResult(
+            source_file=source_label,
+            file_type="pcap",
+            packet_count=len(self._records),
+            time_range=time_range,
+            unique_src_ips=len(unique_src),
+            unique_dst_ips=len(unique_dst),
+            protocol_distribution=protocol_dist,
+            packets=self._records,
+            flows=flows,
+        )
+
+    def stop(self):
+        """Signal the capture to stop early."""
+        self._stop_event.set()
+
+    def _process_packet(self, pkt):
+        """Callback for each captured packet — extract and store as PacketRecord."""
+        if self._stop_event.is_set():
+            return
+
+        if not pkt.haslayer(IP):
+            return
+
+        ip = pkt[IP]
+        ts = datetime.fromtimestamp(float(pkt.time), tz=timezone.utc).isoformat()
+
+        protocol = self._detect_protocol(pkt)
+        src_port, dst_port = self._extract_ports(pkt)
+        tcp_flags = self._extract_tcp_flags(pkt)
+
+        try:
+            payload_size = len(pkt.payload.payload)
+        except Exception:
+            payload_size = 0
+
+        record = PacketRecord(
+            timestamp=ts,
+            src_ip=ip.src,
+            dst_ip=ip.dst,
+            src_port=src_port,
+            dst_port=dst_port,
+            protocol=protocol,
+            size=len(pkt),
+            tcp_flags=tcp_flags,
+            payload_size=payload_size,
+        )
+        self._records.append(record)
+
+    def _build_flows(self) -> list[ConnectionFlow]:
+        """Group captured packets into connection flows."""
+        buckets: dict[tuple, list[PacketRecord]] = defaultdict(list)
+        for r in self._records:
+            key = (r.src_ip, r.dst_ip, r.src_port, r.dst_port, r.protocol)
+            buckets[key].append(r)
+
+        flows = []
+        for (src_ip, dst_ip, src_port, dst_port, protocol), pkts in buckets.items():
+            timestamps = [p.timestamp for p in pkts]
+            start, end = min(timestamps), max(timestamps)
+            start_dt = datetime.fromisoformat(start)
+            end_dt = datetime.fromisoformat(end)
+            duration_sec = (end_dt - start_dt).total_seconds()
+
+            flows.append(ConnectionFlow(
+                src_ip=src_ip,
+                dst_ip=dst_ip,
+                src_port=src_port,
+                dst_port=dst_port,
+                protocol=protocol,
+                packet_count=len(pkts),
+                total_bytes=sum(p.size for p in pkts),
+                duration_seconds=duration_sec,
+                start_time=start,
+                end_time=end,
+            ))
+        return flows
+
+    def _count_protocols(self) -> dict[str, int]:
+        dist: dict[str, int] = defaultdict(int)
+        for r in self._records:
+            dist[r.protocol] += 1
+        return dict(dist)
+
+    @staticmethod
+    def _detect_protocol(pkt) -> str:
+        if pkt.haslayer(DNS):
+            return "DNS"
+        if pkt.haslayer(TCP):
+            return "TCP"
+        if pkt.haslayer(UDP):
+            return "UDP"
+        if pkt.haslayer(ICMP):
+            return "ICMP"
+        return "OTHER"
+
+    @staticmethod
+    def _extract_ports(pkt) -> tuple[int, int]:
+        if pkt.haslayer(TCP):
+            return pkt[TCP].sport, pkt[TCP].dport
+        if pkt.haslayer(UDP):
+            return pkt[UDP].sport, pkt[UDP].dport
+        return 0, 0
+
+    @staticmethod
+    def _extract_tcp_flags(pkt) -> list[str]:
+        if not pkt.haslayer(TCP):
+            return []
+        raw = str(pkt[TCP].flags)
+        return [FLAG_MAP[ch] for ch in raw if ch in FLAG_MAP]

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -4,6 +4,7 @@ import os
 import time
 
 from agents.pcap_parser import PcapParser
+from agents.live_capture import LiveCaptureAgent
 from agents.log_parser import LogParser
 from agents.feature_extractor import FeatureExtractor
 from agents.rule_engine import RuleEngine
@@ -115,6 +116,114 @@ class ThreatAnalysisOrchestrator:
 
         print(f"  Report saved to {report_path}")
         print(f"\nAnalysis complete in {duration:.1f}s")
+        return report_path
+
+    def run_live(
+        self,
+        interface: str | None = None,
+        duration: int = 30,
+        max_packets: int = 10000,
+        bpf_filter: str = "",
+        save_path: str | None = None,
+    ) -> str:
+        """
+        Capture live traffic and run the full analysis pipeline.
+
+        Args:
+            interface:   Network interface name
+            duration:    Capture duration in seconds
+            max_packets: Maximum packets to capture
+            bpf_filter:  BPF filter expression
+            save_path:   Path to save captured PCAP
+
+        Returns:
+            Path to the generated report
+        """
+        start_time = time.time()
+
+        iface_label = interface or "default"
+        print(f"\n[1/7] Capturing live traffic on {iface_label} "
+              f"(max {duration}s, {max_packets} packets)...")
+        if bpf_filter:
+            print(f"  Filter: {bpf_filter}")
+
+        agent = LiveCaptureAgent()
+        parse_result = agent.capture(
+            interface=interface,
+            duration=duration,
+            max_packets=max_packets,
+            bpf_filter=bpf_filter,
+            save_path=save_path,
+        )
+
+        print(f"  Captured {parse_result.packet_count} packets, "
+              f"{parse_result.unique_src_ips} unique sources")
+
+        if save_path:
+            print(f"  Saved to {save_path}")
+
+        # Remaining phases are identical to file-based analysis
+        print("\n[3/7] Extracting features...")
+        extractor = FeatureExtractor()
+        feature_matrix = extractor.extract(parse_result, None)
+        print(f"  {len(feature_matrix.window_starts)} time windows, "
+              f"{len(feature_matrix.feature_names)} features")
+
+        print("\n[4/7] Running rule-based detection...")
+        engine = RuleEngine()
+        rule_alerts = engine.analyze(parse_result, None)
+        print(f"  {len(rule_alerts)} rule-based alerts")
+
+        print("\n[5/7] Running ML anomaly detection...")
+        detector = AnomalyDetector()
+        anomaly_alerts = detector.detect(feature_matrix)
+        print(f"  {len(anomaly_alerts)} anomalous time windows")
+
+        print("\n[6/7] Classifying threats...")
+        classifier = ThreatClassifier()
+        elapsed = time.time() - start_time
+        threat_report = classifier.classify(
+            rule_alerts, anomaly_alerts,
+            parse_result.packet_count, parse_result.time_range, elapsed,
+        )
+        print(f"  {threat_report.total_threats} threats identified "
+              f"({threat_report.critical_count} critical)")
+
+        print("\n[7/7] Generating report...")
+        summary = AnalysisSummary(
+            source_files=[f"live:{iface_label}"],
+            total_packets=parse_result.packet_count,
+            total_log_entries=0,
+            time_range=parse_result.time_range,
+            unique_ips=parse_result.unique_src_ips + parse_result.unique_dst_ips,
+            protocol_breakdown=parse_result.protocol_distribution,
+            threat_summary=threat_report,
+        )
+
+        pps_idx = feature_matrix.feature_names.index("packets_per_second")
+        traffic_timeline = [
+            (ws, float(feature_matrix.features[i][pps_idx]))
+            for i, ws in enumerate(feature_matrix.window_starts)
+        ]
+        anomaly_scores = [
+            (a.time_window_start, a.anomaly_score)
+            for a in anomaly_alerts
+        ]
+
+        chart_gen = ChartGenerator(os.path.join(self.output_dir, "charts"))
+        viz = chart_gen.generate_all(
+            threat_report, parse_result.protocol_distribution,
+            traffic_timeline, anomaly_scores,
+        )
+
+        if self.report_format == "pdf":
+            report_gen = PDFReportGenerator(self.output_dir)
+        else:
+            report_gen = ReportGenerator(self.output_dir)
+        report_path = report_gen.generate(summary, viz)
+
+        print(f"  Report saved to {report_path}")
+        print(f"\nLive analysis complete in {elapsed:.1f}s")
         return report_path
 
     def run_demo(self) -> str:

--- a/main.py
+++ b/main.py
@@ -45,6 +45,42 @@ def main():
         default="docx",
         help="Report output format (default: docx)",
     )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Capture live network traffic instead of reading files",
+    )
+    parser.add_argument(
+        "--interface",
+        type=str,
+        default=None,
+        help="Network interface for live capture (e.g., en0, eth0)",
+    )
+    parser.add_argument(
+        "--duration",
+        type=int,
+        default=30,
+        help="Capture duration in seconds (default: 30, max: 300)",
+    )
+    parser.add_argument(
+        "--max-packets",
+        type=int,
+        default=10000,
+        help="Maximum number of packets to capture (default: 10000)",
+    )
+    parser.add_argument(
+        "--filter",
+        type=str,
+        default="",
+        dest="bpf_filter",
+        help="BPF filter for live capture (e.g., 'tcp port 80')",
+    )
+    parser.add_argument(
+        "--save-pcap",
+        type=str,
+        default=None,
+        help="Save live capture to a PCAP file",
+    )
 
     args = parser.parse_args()
 
@@ -54,7 +90,15 @@ def main():
             report_format=args.format,
         )
 
-        if args.demo:
+        if args.live:
+            orchestrator.run_live(
+                interface=args.interface,
+                duration=args.duration,
+                max_packets=args.max_packets,
+                bpf_filter=args.bpf_filter,
+                save_path=args.save_pcap,
+            )
+        elif args.demo:
             orchestrator.run_demo()
         elif args.files:
             orchestrator.run(args.files)

--- a/tests/test_live_capture.py
+++ b/tests/test_live_capture.py
@@ -1,0 +1,158 @@
+"""Tests for LiveCaptureAgent — structure and helper methods.
+
+Note: Actual packet capture requires elevated privileges and a network
+interface. These tests verify the agent's internal logic using mock packets.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from datetime import datetime, timezone
+
+from scapy.all import IP, TCP, UDP, DNS, Ether
+
+from agents.live_capture import LiveCaptureAgent
+from models.network import PacketRecord, ParseResult
+
+
+@pytest.fixture
+def agent():
+    return LiveCaptureAgent()
+
+
+@pytest.fixture
+def mock_packets():
+    """Create a list of mock scapy packets."""
+    packets = []
+
+    # TCP SYN packet
+    pkt1 = Ether() / IP(src="192.168.1.10", dst="10.0.0.1") / TCP(sport=12345, dport=80, flags="S")
+    pkt1.time = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc).timestamp()
+    packets.append(pkt1)
+
+    # TCP ACK packet
+    pkt2 = Ether() / IP(src="10.0.0.1", dst="192.168.1.10") / TCP(sport=80, dport=12345, flags="A")
+    pkt2.time = datetime(2025, 1, 15, 10, 0, 1, tzinfo=timezone.utc).timestamp()
+    packets.append(pkt2)
+
+    # UDP packet
+    pkt3 = Ether() / IP(src="192.168.1.10", dst="8.8.8.8") / UDP(sport=5353, dport=53)
+    pkt3.time = datetime(2025, 1, 15, 10, 0, 2, tzinfo=timezone.utc).timestamp()
+    packets.append(pkt3)
+
+    return packets
+
+
+class TestPacketProcessing:
+    def test_process_tcp_packet(self, agent, mock_packets):
+        agent._process_packet(mock_packets[0])
+        assert len(agent._records) == 1
+        record = agent._records[0]
+        assert record.src_ip == "192.168.1.10"
+        assert record.dst_ip == "10.0.0.1"
+        assert record.src_port == 12345
+        assert record.dst_port == 80
+        assert record.protocol == "TCP"
+        assert "SYN" in record.tcp_flags
+
+    def test_process_udp_packet(self, agent, mock_packets):
+        agent._process_packet(mock_packets[2])
+        assert len(agent._records) == 1
+        record = agent._records[0]
+        assert record.protocol == "UDP"
+        assert record.dst_port == 53
+
+    def test_process_multiple_packets(self, agent, mock_packets):
+        for pkt in mock_packets:
+            agent._process_packet(pkt)
+        assert len(agent._records) == 3
+
+    def test_stop_event_prevents_processing(self, agent, mock_packets):
+        agent._stop_event.set()
+        agent._process_packet(mock_packets[0])
+        assert len(agent._records) == 0
+
+
+class TestFlowBuilding:
+    def test_builds_flows(self, agent, mock_packets):
+        for pkt in mock_packets:
+            agent._process_packet(pkt)
+        flows = agent._build_flows()
+        # 3 packets should form 3 different flows (different src/dst combos)
+        assert len(flows) >= 2
+
+    def test_flow_has_correct_fields(self, agent, mock_packets):
+        for pkt in mock_packets:
+            agent._process_packet(pkt)
+        flows = agent._build_flows()
+        for flow in flows:
+            assert flow.packet_count > 0
+            assert flow.total_bytes > 0
+            assert flow.protocol in ("TCP", "UDP", "DNS", "ICMP", "OTHER")
+
+
+class TestProtocolCounting:
+    def test_counts_protocols(self, agent, mock_packets):
+        for pkt in mock_packets:
+            agent._process_packet(pkt)
+        dist = agent._count_protocols()
+        assert "TCP" in dist
+        assert "UDP" in dist
+        assert dist["TCP"] == 2
+        assert dist["UDP"] == 1
+
+
+class TestProtocolDetection:
+    def test_detect_tcp(self, agent):
+        pkt = IP() / TCP()
+        assert agent._detect_protocol(pkt) == "TCP"
+
+    def test_detect_udp(self, agent):
+        pkt = IP() / UDP()
+        assert agent._detect_protocol(pkt) == "UDP"
+
+    def test_detect_dns(self, agent):
+        pkt = IP() / UDP() / DNS()
+        assert agent._detect_protocol(pkt) == "DNS"
+
+
+class TestPortExtraction:
+    def test_tcp_ports(self, agent):
+        pkt = IP() / TCP(sport=1234, dport=443)
+        src, dst = agent._extract_ports(pkt)
+        assert src == 1234
+        assert dst == 443
+
+    def test_udp_ports(self, agent):
+        pkt = IP() / UDP(sport=5353, dport=53)
+        src, dst = agent._extract_ports(pkt)
+        assert src == 5353
+        assert dst == 53
+
+    def test_no_ports_for_icmp(self, agent):
+        from scapy.all import ICMP
+        pkt = IP() / ICMP()
+        src, dst = agent._extract_ports(pkt)
+        assert src == 0
+        assert dst == 0
+
+
+class TestCaptureParameters:
+    def test_duration_clamped_max(self, agent):
+        with patch("agents.live_capture.sniff") as mock_sniff:
+            mock_sniff.return_value = []
+            try:
+                agent.capture(duration=999, max_packets=1)
+            except ValueError:
+                pass
+            call_kwargs = mock_sniff.call_args[1]
+            assert call_kwargs["timeout"] == 300
+
+    def test_duration_clamped_min(self, agent):
+        with patch("agents.live_capture.sniff") as mock_sniff:
+            mock_sniff.return_value = []
+            try:
+                agent.capture(duration=-5, max_packets=1)
+            except ValueError:
+                pass
+            call_kwargs = mock_sniff.call_args[1]
+            assert call_kwargs["timeout"] == 1


### PR DESCRIPTION
## Summary
- New `LiveCaptureAgent` using scapy `sniff()` for real-time traffic capture
- Produces the same `ParseResult` format as `PcapParser`, fully compatible with the existing analysis pipeline
- CLI flags: `--live`, `--interface`, `--duration`, `--max-packets`, `--filter`, `--save-pcap`
- Duration clamped to 1-300s, packet count clamped to 1-100000
- Optional BPF filtering and PCAP file export of captured traffic
- Orchestrator `run_live()` feeds captured packets through the full 7-phase pipeline

## Test plan
- [x] TCP/UDP packet processing and field extraction
- [x] Flow building from captured packets
- [x] Protocol counting and detection
- [x] Port extraction for TCP/UDP/ICMP
- [x] Stop event prevents further processing
- [x] Duration clamping (min/max)
- [x] All 100 existing + new tests pass

Closes #1