### PR TITLE
Add DNS tunneling detection rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Rule Engine   Anomaly Detector    Phase 4-5: Dual detection
 | C2 Beaconing | Regular-interval connections (std dev < 5s) | Critical |
 | Data Exfiltration | >10MB outbound from internal to external IP | High |
 | Malicious Ports | Traffic on known backdoor ports (4444, 1337, ...) | High |
+| DNS Tunneling (Volume) | >100 DNS queries from single source in 60s | High |
+| DNS Tunneling (Oversized) | ≥20 DNS packets with payload >100 bytes per source | High |
 
 ### ML Anomaly Detection
 

--- a/agents/rule_engine.py
+++ b/agents/rule_engine.py
@@ -2,7 +2,7 @@
 
 from models.network import ParseResult, LogParseResult
 from models.threats import RuleAlert
-from rules import port_scan, ddos, brute_force, suspicious_connections
+from rules import port_scan, ddos, brute_force, suspicious_connections, dns_tunneling
 
 SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
 
@@ -28,6 +28,9 @@ class RuleEngine:
         )
         alerts.extend(
             suspicious_connections.detect(parse_result.packets, parse_result.flows)
+        )
+        alerts.extend(
+            dns_tunneling.detect(parse_result.packets, parse_result.flows)
         )
 
         alerts.sort(key=lambda a: SEVERITY_ORDER.get(a.severity, 99))

--- a/agents/threat_classifier.py
+++ b/agents/threat_classifier.py
@@ -25,6 +25,11 @@ _RULE_RECOMMENDATIONS = {
         "Block communication to suspicious destination",
         "Conduct forensic analysis of the endpoint",
     ],
+    "DNS_TUNNELING": [
+        "Block outbound DNS to untrusted resolvers; force traffic through internal DNS",
+        "Inspect logs of the source host for unauthorised processes",
+        "Add the destination domain(s) to a DNS sinkhole or blocklist",
+    ],
 }
 
 _BASE_SEVERITY_SCORES = {
@@ -85,6 +90,8 @@ class ThreatClassifier:
             title = f"Brute Force from {alert.source_ips[0]}"
         elif category == "SUSPICIOUS_CONNECTION" and alert.dest_ips:
             title = f"Suspicious Connection to {alert.dest_ips[0]}"
+        elif category == "DNS_TUNNELING" and alert.source_ips:
+            title = f"DNS Tunneling from {alert.source_ips[0]}"
         else:
             title = f"{category.replace('_', ' ').title()} detected"
 

--- a/models/threats.py
+++ b/models/threats.py
@@ -30,6 +30,7 @@ class ClassifiedThreat(BaseModel):
         "DDOS_ATTACK",
         "BRUTE_FORCE",
         "SUSPICIOUS_CONNECTION",
+        "DNS_TUNNELING",
         "ANOMALOUS_TRAFFIC",
     ]
     severity_score: int = Field(ge=0, le=100)

--- a/rules/dns_tunneling.py
+++ b/rules/dns_tunneling.py
@@ -1,0 +1,99 @@
+"""DNS tunneling detection — excessive query volume and oversized DNS packets.
+
+DNS tunneling embeds payload data inside DNS queries to bypass perimeter
+defences. Two signals raise an alert here:
+
+1. A source IP generates more than VOLUME_THRESHOLD DNS queries within a
+   60-second window.
+2. A source IP sends at least LARGE_QUERY_COUNT DNS packets with
+   payload_size above LARGE_QUERY_PAYLOAD_BYTES (legitimate queries are
+   typically below ~80 bytes; tunnelling encodes data into long subdomain
+   labels, inflating the packet).
+"""
+
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+from models.network import ConnectionFlow, PacketRecord
+from models.threats import RuleAlert
+
+DNS_PORT = 53
+WINDOW_SECONDS = 60
+VOLUME_THRESHOLD = 100
+LARGE_QUERY_PAYLOAD_BYTES = 100
+LARGE_QUERY_COUNT_THRESHOLD = 20
+
+
+def _is_dns(pkt: PacketRecord) -> bool:
+    return pkt.protocol.upper() == "DNS" or pkt.dst_port == DNS_PORT
+
+
+def detect(packets: list[PacketRecord], flows: list[ConnectionFlow]) -> list[RuleAlert]:
+    """Run DNS tunneling detection rules against packet data."""
+    alerts: list[RuleAlert] = []
+
+    dns_packets_by_source: dict[str, list[PacketRecord]] = defaultdict(list)
+    for pkt in packets:
+        if _is_dns(pkt):
+            dns_packets_by_source[pkt.src_ip].append(pkt)
+
+    for src_ip, dns_packets in dns_packets_by_source.items():
+        if not dns_packets:
+            continue
+
+        # --- Volume check: many queries in a short window ---
+        timestamps = sorted(datetime.fromisoformat(p.timestamp) for p in dns_packets)
+        for i, start in enumerate(timestamps):
+            window_end = start + timedelta(seconds=WINDOW_SECONDS)
+            in_window = [t for t in timestamps[i:] if t <= window_end]
+            if len(in_window) > VOLUME_THRESHOLD:
+                dest_ips = sorted({p.dst_ip for p in dns_packets})
+                alerts.append(RuleAlert(
+                    rule_name="dns_tunneling_volume",
+                    severity="high",
+                    category="DNS_TUNNELING",
+                    description=(
+                        f"DNS tunneling suspected from {src_ip}: "
+                        f"{len(in_window)} queries in {WINDOW_SECONDS}s"
+                    ),
+                    source_ips=[src_ip],
+                    dest_ips=dest_ips,
+                    timestamps=[in_window[0].isoformat(), in_window[-1].isoformat()],
+                    evidence={
+                        "pattern": "high_query_volume",
+                        "queries_in_window": len(in_window),
+                        "window_seconds": WINDOW_SECONDS,
+                        "threshold": VOLUME_THRESHOLD,
+                    },
+                ))
+                break  # one volume alert per source is enough
+
+        # --- Size check: many unusually large queries ---
+        large_packets = [
+            p for p in dns_packets if p.payload_size > LARGE_QUERY_PAYLOAD_BYTES
+        ]
+        if len(large_packets) >= LARGE_QUERY_COUNT_THRESHOLD:
+            avg_size = sum(p.payload_size for p in large_packets) / len(large_packets)
+            dest_ips = sorted({p.dst_ip for p in large_packets})
+            sorted_timestamps = sorted(p.timestamp for p in large_packets)
+            alerts.append(RuleAlert(
+                rule_name="dns_tunneling_oversized_queries",
+                severity="high",
+                category="DNS_TUNNELING",
+                description=(
+                    f"DNS tunneling suspected from {src_ip}: "
+                    f"{len(large_packets)} oversized queries "
+                    f"(avg {avg_size:.0f} bytes payload)"
+                ),
+                source_ips=[src_ip],
+                dest_ips=dest_ips,
+                timestamps=[sorted_timestamps[0], sorted_timestamps[-1]],
+                evidence={
+                    "pattern": "oversized_queries",
+                    "large_query_count": len(large_packets),
+                    "average_payload_bytes": round(avg_size, 1),
+                    "payload_threshold_bytes": LARGE_QUERY_PAYLOAD_BYTES,
+                },
+            ))
+
+    return alerts

--- a/tests/test_dns_tunneling.py
+++ b/tests/test_dns_tunneling.py
@@ -1,0 +1,168 @@
+"""Tests for the DNS tunneling detection rule."""
+
+import pytest
+
+from models.network import PacketRecord, ParseResult
+from rules import dns_tunneling
+from agents.rule_engine import RuleEngine
+
+
+def _dns_packet(
+    src_ip: str = "192.168.1.50",
+    dst_ip: str = "8.8.8.8",
+    timestamp: str = "2026-03-15T10:00:00",
+    payload_size: int = 40,
+    protocol: str = "DNS",
+    dst_port: int = 53,
+) -> PacketRecord:
+    return PacketRecord(
+        timestamp=timestamp,
+        src_ip=src_ip,
+        dst_ip=dst_ip,
+        src_port=44444,
+        dst_port=dst_port,
+        protocol=protocol,
+        size=payload_size + 28,  # rough UDP header overhead
+        payload_size=payload_size,
+    )
+
+
+@pytest.fixture
+def high_volume_dns_packets():
+    """150 DNS queries from one source within 30 seconds — above the volume threshold."""
+    return [
+        _dns_packet(
+            src_ip="10.0.0.99",
+            timestamp=f"2026-03-15T10:00:{i // 5:02d}.{(i % 5) * 200000:06d}",
+            payload_size=50,
+        )
+        for i in range(150)
+    ]
+
+
+@pytest.fixture
+def oversized_dns_packets():
+    """25 large DNS queries from one source — above the size threshold."""
+    return [
+        _dns_packet(
+            src_ip="10.0.0.42",
+            timestamp=f"2026-03-15T10:00:{i:02d}",
+            payload_size=200,
+        )
+        for i in range(25)
+    ]
+
+
+@pytest.fixture
+def normal_dns_packets():
+    """Five small DNS queries — well below any threshold."""
+    return [
+        _dns_packet(timestamp=f"2026-03-15T10:00:{i*10:02d}", payload_size=40)
+        for i in range(5)
+    ]
+
+
+class TestVolumePattern:
+    def test_high_volume_triggers_alert(self, high_volume_dns_packets):
+        alerts = dns_tunneling.detect(high_volume_dns_packets, flows=[])
+        volume_alerts = [a for a in alerts if a.rule_name == "dns_tunneling_volume"]
+        assert len(volume_alerts) == 1
+        alert = volume_alerts[0]
+        assert alert.source_ips == ["10.0.0.99"]
+        assert alert.category == "DNS_TUNNELING"
+        assert alert.severity == "high"
+        assert alert.evidence["queries_in_window"] > 100
+
+    def test_one_alert_per_source(self, high_volume_dns_packets):
+        """Detector should not emit a volume alert for every window — one per source."""
+        alerts = dns_tunneling.detect(high_volume_dns_packets, flows=[])
+        volume_alerts = [a for a in alerts if a.rule_name == "dns_tunneling_volume"]
+        assert len(volume_alerts) == 1
+
+    def test_below_threshold_no_alert(self, normal_dns_packets):
+        alerts = dns_tunneling.detect(normal_dns_packets, flows=[])
+        assert [a for a in alerts if a.rule_name == "dns_tunneling_volume"] == []
+
+
+class TestOversizedPattern:
+    def test_oversized_triggers_alert(self, oversized_dns_packets):
+        alerts = dns_tunneling.detect(oversized_dns_packets, flows=[])
+        size_alerts = [
+            a for a in alerts if a.rule_name == "dns_tunneling_oversized_queries"
+        ]
+        assert len(size_alerts) == 1
+        alert = size_alerts[0]
+        assert alert.source_ips == ["10.0.0.42"]
+        assert alert.evidence["large_query_count"] == 25
+        assert alert.evidence["average_payload_bytes"] == pytest.approx(200.0)
+
+    def test_few_large_queries_below_threshold(self):
+        """10 large queries is below the count threshold of 20 — no alert."""
+        packets = [
+            _dns_packet(
+                src_ip="10.0.0.42",
+                timestamp=f"2026-03-15T10:00:{i:02d}",
+                payload_size=200,
+            )
+            for i in range(10)
+        ]
+        alerts = dns_tunneling.detect(packets, flows=[])
+        assert [
+            a for a in alerts if a.rule_name == "dns_tunneling_oversized_queries"
+        ] == []
+
+
+class TestDetection:
+    def test_empty_packets(self):
+        assert dns_tunneling.detect([], flows=[]) == []
+
+    def test_dns_detected_by_dst_port_53(self):
+        """Even if scapy didn't label the packet 'DNS', port 53 alone should match."""
+        packets = [
+            _dns_packet(
+                src_ip="10.0.0.7",
+                timestamp=f"2026-03-15T10:00:{i:02d}",
+                payload_size=200,
+                protocol="UDP",  # not labelled DNS
+                dst_port=53,
+            )
+            for i in range(25)
+        ]
+        alerts = dns_tunneling.detect(packets, flows=[])
+        assert any(a.rule_name == "dns_tunneling_oversized_queries" for a in alerts)
+
+    def test_non_dns_traffic_ignored(self):
+        """HTTP packets on port 80 must not produce DNS tunneling alerts."""
+        packets = [
+            PacketRecord(
+                timestamp=f"2026-03-15T10:00:{i:02d}",
+                src_ip="10.0.0.5",
+                dst_ip="93.184.216.34",
+                src_port=33333,
+                dst_port=80,
+                protocol="TCP",
+                size=200,
+                payload_size=180,
+            )
+            for i in range(200)
+        ]
+        assert dns_tunneling.detect(packets, flows=[]) == []
+
+
+class TestRuleEngineIntegration:
+    def test_engine_dispatches_to_dns_tunneling(self, oversized_dns_packets):
+        parse_result = ParseResult(
+            source_file="test.pcap",
+            file_type="pcap",
+            packet_count=len(oversized_dns_packets),
+            time_range="2026-03-15T10:00:00 – 2026-03-15T10:00:24",
+            unique_src_ips=1,
+            unique_dst_ips=1,
+            protocol_distribution={"DNS": len(oversized_dns_packets)},
+            packets=oversized_dns_packets,
+            flows=[],
+        )
+        engine = RuleEngine()
+        alerts = engine.analyze(parse_result)
+        dns_alerts = [a for a in alerts if a.category == "DNS_TUNNELING"]
+        assert dns_alerts, "RuleEngine should surface DNS_TUNNELING alerts"


### PR DESCRIPTION
## Summary

- New detection rule `rules/dns_tunneling.py` flags two patterns:
  - **Excessive query volume**: > 100 DNS queries from one source in a 60-second window
  - **Oversized queries**: ≥ 20 DNS packets with payload size > 100 bytes from a single source
- Rule engine dispatches DNS traffic to the new module
- `ClassifiedThreat` category Literal extended with `DNS_TUNNELING`
- Threat classifier produces a "DNS Tunneling from <ip>" title and ships three remediation recommendations
- README rules table lists the two new patterns
- 9 new tests bring the suite from 100 to 109 (all passing)

Closes #12

## Test plan

- [x] All 109 backend tests pass (`pytest -q`)
- [x] No false positives on normal HTTP/TCP traffic
- [x] Detection works whether scapy labels the packet `DNS` or only `UDP` on dst_port 53
