### PR TITLE
Run on Python 3.11 to 3.13 for NumPy 2.x, pandas 3.x and scikit-learn 1.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Multi-agent network threat detection system combining rule-based signature matching with ML anomaly detection to analyze PCAP files and server logs.
 
 ![CI](https://github.com/eugen-goebel/network-threat-analyzer/actions/workflows/tests.yml/badge.svg)
-![Python 3.10+](https://img.shields.io/badge/Python-3.10+-3776AB?logo=python&logoColor=white)
+![Python 3.10+](https://img.shields.io/badge/Python-3.11+-3776AB?logo=python&logoColor=white)
 ![Tests](https://img.shields.io/badge/Tests-54+-passing?color=brightgreen)
 ![scikit-learn](https://img.shields.io/badge/scikit--learn-1.5+-F7931E?logo=scikit-learn&logoColor=white)
 ![Streamlit](https://img.shields.io/badge/Streamlit-Dashboard-FF4B4B?logo=streamlit&logoColor=white)


### PR DESCRIPTION
NumPy 2.x, pandas 3.0 and scikit-learn 1.9 all require Python 3.11+, which is why those three bumps failed CI on the 3.10 job.

What changed:
- test matrix moved to 3.11, 3.12, 3.13
- Python badge updated to 3.11+

The existing pins already allow the new majors. The full suite passes locally on NumPy 2.4, pandas 3.0.3 and scikit-learn 1.9.0.

Closes #16